### PR TITLE
File location changed on api.tihmstar.net -> Allow redirects

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ sudo cp /usr/local/opt/openssl/lib/libcrypto*dylib /opt/local/lib/
 
 echo "Downloading latest futurerestore..."
 mkdir ~/.futurerestore
-curl -o ~/.futurerestore/futurerestore.zip http://api.tihmstar.net/builds/futurerestore/futurerestore-latest.zip
+curl -L -o ~/.futurerestore/futurerestore.zip http://api.tihmstar.net/builds/futurerestore/futurerestore-latest.zip
 cd ~/.futurerestore
 unzip futurerestore.zip
 chmod +x futurerestore_macos


### PR DESCRIPTION
The file location has changed on api.tihmstar.net and the server now redirects to the correct location. Without the modification in the install.sh, the setup script will not work anymore since futurerestore cannot be downloaded.

The "-L" flag allows cURL to follow redirects.